### PR TITLE
Add memory_metrics to canister_status.

### DIFF
--- a/docs/references/_attachments/ic.did
+++ b/docs/references/_attachments/ic.did
@@ -248,6 +248,18 @@ type canister_status_result = record {
     settings : definite_canister_settings;
     module_hash : opt blob;
     memory_size : nat;
+    memory_metrics : record {
+        // execution memory
+        heap_size : nat;
+        stable_size : nat;
+        global_size : nat;
+        wasm_binary_size : nat;
+        custom_sections_size : nat;
+        // system memory
+        canister_history_size : nat;
+        wasm_chunk_store_size : nat;
+        snapshot_size : nat;
+    };
     cycles : nat;
     reserved_cycles : nat;
     idle_cycles_burned_per_day : nat;

--- a/docs/references/ic-interface-spec.md
+++ b/docs/references/ic-interface-spec.md
@@ -2273,7 +2273,25 @@ Indicates various information about the canister. It contains:
 
 -   A SHA256 hash of the module installed on the canister. This is `null` if the canister is empty.
 
--   The actual memory usage of the canister.
+-   The total memory usage of the canister, which includes all types of memory consumed by the canister.
+
+-   Detailed breakdown of memory usage into individual components (in bytes):
+
+    * `heap_size`: Represents the total Wasm memory usage of the execution state, which includes the heap memory used by the canister's WebAssembly code.
+
+    * `stable_size`: Indicates the total stable memory usage of the execution state, which is the memory that persists across canister upgrades.
+
+    * `global_size`: The total global memory usage of the execution state, encompassing all global variables used by the canister.
+
+    * `wasm_binary_size`: The total memory occupied by the Wasm binary itself within the execution state.
+
+    * `custom_sections_size`: The memory used by custom sections within the execution state, which may include additional metadata or configuration data.
+
+    * `canister_history_size`: The total memory allocated for storing the canister's history within the system state, which includes records of past actions and changes.
+
+    * `wasm_chunk_store_size`: The memory used by the Wasm chunk store within the system state, which is used to store large Wasm modules in chunks.
+
+    * `snapshot_size`: The total memory consumed by snapshots within the system state, which are used to capture the state of the canister at specific points in time.
 
 -   The cycle balance of the canister.
 


### PR DESCRIPTION
Specification changes to reflect updates in https://github.com/CycleOperators/ic/pull/1.
These two branches might not be in sync, this will be the reference for the public API changes.